### PR TITLE
Implement panic screen output

### DIFF
--- a/drivers/gpu/drm/msm/Makefile
+++ b/drivers/gpu/drm/msm/Makefile
@@ -175,12 +175,13 @@ msm_drm-$(CONFIG_DRM_MSM) += \
 	msm_gem_prime.o \
 	msm_gem_submit.o \
 	msm_gem_shrinker.o \
-	msm_gem_vma.o \
-	msm_gpu.o \
-	msm_iommu.o \
-	msm_smmu.o \
-	msm_perf.o \
-	msm_rd.o \
+        msm_gem_vma.o \
+        msm_gpu.o \
+        msm_iommu.o \
+        msm_smmu.o \
+        msm_perf.o \
+        msm_panic.o \
+        msm_rd.o \
 	msm_ringbuffer.o \
 	msm_prop.o \
 	msm_fence.o \

--- a/drivers/gpu/drm/msm/msm_drv.c
+++ b/drivers/gpu/drm/msm/msm_drv.c
@@ -47,6 +47,7 @@
 #include "msm_kms.h"
 #include "sde_wb.h"
 #include "dsi_display.h"
+#include "msm_panic.h"
 
 /*
  * MSM driver version:
@@ -321,8 +322,9 @@ static int msm_drm_uninit(struct device *dev)
 
 	component_unbind_all(dev, ddev);
 
-	sde_dbg_destroy();
-	debugfs_remove_recursive(priv->debug_root);
+       sde_dbg_destroy();
+       debugfs_remove_recursive(priv->debug_root);
+       msm_unregister_panic_notifier();
 
 	sde_power_client_destroy(&priv->phandle, priv->pclient);
 	sde_power_resource_deinit(pdev, &priv->phandle);
@@ -890,9 +892,11 @@ static int msm_drm_init(struct device *dev, struct drm_driver *drv)
 		}
 	}
 
-	drm_kms_helper_poll_init(ddev);
+       drm_kms_helper_poll_init(ddev);
 
-	return 0;
+       msm_register_panic_notifier();
+
+       return 0;
 
 fail:
 	msm_drm_uninit(dev);

--- a/drivers/gpu/drm/msm/msm_panic.c
+++ b/drivers/gpu/drm/msm/msm_panic.c
@@ -1,0 +1,54 @@
+#include <linux/notifier.h>
+#include <linux/fb.h>
+#include <linux/console.h>
+#include <linux/vt_kern.h>
+#include <linux/printk.h>
+
+static int msm_panic_handler(struct notifier_block *nb, unsigned long event, void *ptr)
+{
+    struct fb_info *info = NULL;
+    struct fb_fillrect rect;
+    int i;
+
+    if (num_registered_fb > 0)
+        info = registered_fb[0];
+
+    if (info) {
+        rect.dx = 0;
+        rect.dy = 0;
+        rect.width = info->var.xres;
+        rect.height = info->var.yres;
+        rect.color = 0xFFFFFFFF;
+        rect.rop = ROP_COPY;
+        if (info->fbops && info->fbops->fb_fillrect)
+            info->fbops->fb_fillrect(info, &rect);
+        else
+            sys_fillrect(info, &rect);
+    }
+
+    console_lock();
+    for (i = 0; i < MAX_NR_CONSOLES; i++) {
+        if (!vc_cons[i].d)
+            continue;
+        invert_screen(vc_cons[i].d, 0, vc_cons[i].d->vc_screenbuf_size, 0);
+    }
+    console_unlock();
+
+    pr_emerg("%s", (char *)ptr);
+    console_flush_on_panic();
+    return NOTIFY_DONE;
+}
+
+static struct notifier_block msm_panic_nb = {
+    .notifier_call = msm_panic_handler,
+};
+
+int msm_register_panic_notifier(void)
+{
+    return atomic_notifier_chain_register(&panic_notifier_list, &msm_panic_nb);
+}
+
+void msm_unregister_panic_notifier(void)
+{
+    atomic_notifier_chain_unregister(&panic_notifier_list, &msm_panic_nb);
+}

--- a/drivers/gpu/drm/msm/msm_panic.h
+++ b/drivers/gpu/drm/msm/msm_panic.h
@@ -1,0 +1,7 @@
+#ifndef __MSM_PANIC_H__
+#define __MSM_PANIC_H__
+
+int msm_register_panic_notifier(void);
+void msm_unregister_panic_notifier(void);
+
+#endif /* __MSM_PANIC_H__ */

--- a/drivers/tty/vt/vt.c
+++ b/drivers/tty/vt/vt.c
@@ -2976,7 +2976,7 @@ static void con_cleanup(struct tty_struct *tty)
 	tty_port_put(&vc->port);
 }
 
-static int default_color           = 7; /* white */
+static int default_color           = 0x70; /* black on white */
 static int default_italic_color    = 2; // green (ASCII)
 static int default_underline_color = 3; // cyan (ASCII)
 module_param_named(color, default_color, int, S_IRUGO | S_IWUSR);


### PR DESCRIPTION
## Summary
- add MSM DRM panic notifier to render kernel panic messages directly on screen
- hook notifier registration in msm driver
- compile panic code in msm DRM makefile
- set console default color to black on white for panic output

## Testing
- `make vendor/xiaomi/mi845_defconfig` *(fails: can't open drivers/kernelsu/Kconfig)*
- `make vendor/xiaomi/polaris.config` *(fails: base file .config does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_685ea1140c148328b6d6b81989b6e473